### PR TITLE
Update semantic-release to v21

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v3
         with:
           dry_run: true
-          semantic_version: '^19.0.0'
+          semantic_version: '^21.0.0'
   release:
     name: Release version
     runs-on: ubuntu-latest


### PR DESCRIPTION
@seveibar looks like the commit analyzer is confused on the alpha branch and keeps wanting to release the same version. Maybe this is fixed in the latest version of semantic release.