### PR TITLE
fix: Add device.errors and device.warnings

### DIFF
--- a/src/lib/database/store.ts
+++ b/src/lib/database/store.ts
@@ -115,6 +115,8 @@ const initializer = immer<DatabaseState & DatabaseMethods>((set, get) => ({
         ...params.properties,
       },
       workspace_id: params.workspace_id,
+      errors: params.errors ?? [],
+      warnings: params.warnings ?? [],
     } as Device
 
     set({

--- a/src/lib/database/types.ts
+++ b/src/lib/database/types.ts
@@ -54,6 +54,8 @@ export interface DatabaseMethods {
     workspace_id: string
     name: string
     properties?: Partial<Device["properties"]>
+    errors?: Device["errors"]
+    warnings?: Device["warnings"]
   }): Device
   addAccessCode(
     params: {


### PR DESCRIPTION
I'm trying to see `device.errors` and `device.warnings` in the `react` repo but I think these properties are getting filtered out. Not sure if this was the right change to make