### PR TITLE
Fix(AccessCode): add missing errors

### DIFF
--- a/src/lib/database/store.ts
+++ b/src/lib/database/store.ts
@@ -164,6 +164,8 @@ const initializer = immer<DatabaseState & DatabaseMethods>((set, get) => ({
       access_code_id: get()._getNextId("access_code"),
       created_at: params.created_at ?? new Date().toISOString(),
       is_managed: true,
+      errors: [],
+      warnings: [],
       ...params,
     } as AccessCode
 


### PR DESCRIPTION
Required as part of https://github.com/seamapi/react/issues/236, currently adding a new access code doesn't include the required errors/warnings, resulting in this error: 

![CleanShot 2023-07-11 at 20 53 49](https://github.com/seamapi/fake-seam-connect/assets/11449462/9b64debc-b456-4b35-aed7-c5f63977b69d)
