### PR TITLE
fix: /access_codes/update requiring uuid

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1575,7 +1575,7 @@
                 "type": "object",
                 "properties": {
                   "access_code_id": { "type": "string" },
-                  "device_id": { "type": "string", "format": "uuid" },
+                  "device_id": { "type": "string" },
                   "name": { "type": "string" },
                   "code": { "type": "string" },
                   "starts_at": {
@@ -1610,7 +1610,7 @@
           {
             "name": "device_id",
             "in": "query",
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": { "type": "string" },
             "required": false
           },
           {

--- a/src/pages/api/access_codes/update.ts
+++ b/src/pages/api/access_codes/update.ts
@@ -8,7 +8,7 @@ import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
 const json_body = z
   .object({
     access_code_id: z.string(),
-    device_id: z.string().uuid().optional(),
+    device_id: z.string().optional(),
     name: z.string().optional(),
     code: z.string().optional(),
     starts_at: timestamp.optional(),


### PR DESCRIPTION
Previously had a `uuid()`, which fails since we're just using hardcoded ids, like `device_1`.

![CleanShot 2023-07-27 at 16 47 17](https://github.com/seamapi/fake-seam-connect/assets/11449462/7ed6fe56-8ccc-44db-80c9-cba983dcf6f9)
