### PR TITLE
feat: add /thermostats/set_fan_mode endpoint

### DIFF
--- a/src/lib/zod/device.ts
+++ b/src/lib/zod/device.ts
@@ -97,6 +97,8 @@ export const thermostat_device_properties = common_device_properties.extend({
   min_heating_cooling_delta_fahrenheit: z.number(),
 })
 
+export const fan_mode_setting = z.enum(["auto", "on"])
+
 export const device = z.object({
   device_id: z.string(),
   device_type,

--- a/src/pages/api/thermostats/set_fan_mode.ts
+++ b/src/pages/api/thermostats/set_fan_mode.ts
@@ -49,6 +49,6 @@ export default withRouteSpec({
   })
 
   res.status(200).json({
-    action_attempt: sync === true ? action_attempt_sync : action_attempt,
+    action_attempt: sync ? action_attempt_sync : action_attempt,
   })
 })

--- a/src/pages/api/thermostats/set_fan_mode.ts
+++ b/src/pages/api/thermostats/set_fan_mode.ts
@@ -1,0 +1,54 @@
+import { NotFoundException } from "nextlove"
+import { z } from "zod"
+
+import {
+  action_attempt,
+  fan_mode_setting,
+  THERMOSTAT_DEVICE_TYPES,
+} from "lib/zod/index.ts"
+
+import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
+
+export default withRouteSpec({
+  auth: "cst_ak_pk",
+  methods: ["POST"],
+  jsonBody: z.object({
+    device_id: z.string(),
+    fan_mode_setting,
+    sync: z.boolean().default(false),
+  }),
+  jsonResponse: z.object({
+    action_attempt,
+  }),
+} as const)(async (req, res) => {
+  const { device_id, sync } = req.body
+
+  const device = req.db.devices.find((device) => {
+    if (!THERMOSTAT_DEVICE_TYPES.includes(device.device_type)) {
+      return false
+    }
+
+    return device.device_id === device_id
+  })
+
+  if (device == null) {
+    throw new NotFoundException({
+      type: "device_not_found",
+      message: `Could not find a thermostat with device_id`,
+      data: { device_id },
+    })
+  }
+
+  const action_attempt = req.db.addActionAttempt({
+    action_type: "SET_FAN_MODE",
+  })
+
+  const action_attempt_sync = req.db.updateActionAttempt({
+    action_attempt_id: action_attempt.action_attempt_id,
+    status: "success",
+  })
+
+  res.status(200).json({
+    action_attempt: sync === true ? action_attempt_sync : action_attempt,
+  })
+})

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -2594,6 +2594,46 @@ export type Routes = {
       ok: boolean
     }
   }
+  "/thermostats/set_fan_mode": {
+    route: "/thermostats/set_fan_mode"
+    method: "POST"
+    queryParams: {}
+    jsonBody: {
+      device_id: string
+      fan_mode_setting: "auto" | "on"
+      sync?: boolean
+    }
+    commonParams: {}
+    formData: {}
+    jsonResponse: {
+      action_attempt:
+        | {
+            status: "success"
+            action_type: string
+            action_attempt_id: string
+            result?: any
+            error: null
+          }
+        | {
+            status: "pending"
+            action_type: string
+            action_attempt_id: string
+            result: null
+            error: null
+          }
+        | {
+            status: "error"
+            action_type: string
+            action_attempt_id: string
+            result: null
+            error: {
+              type: string
+              message: string
+            }
+          }
+      ok: boolean
+    }
+  }
 }
 
 export type RouteResponse<Path extends keyof Routes> =

--- a/test/api/thermostats/set_fan_mode.test.ts
+++ b/test/api/thermostats/set_fan_mode.test.ts
@@ -1,0 +1,34 @@
+import test from "ava"
+
+import { getTestServer } from "fixtures/get-test-server.ts"
+import { seed } from "lib/database/seed.ts"
+
+test("POST /thermostats/set_fan_mode with api key", async (t) => {
+  const { axios, db } = await getTestServer(t, { seed: false })
+  const seed_result = seed(db)
+
+  axios.defaults.headers.common.Authorization = `Bearer ${seed_result.seam_apikey1_token}`
+
+  const {
+    data: { action_attempt },
+    status,
+  } = await axios.post(
+    "/thermostats/set_fan_mode",
+    {
+      device_id: seed_result.ecobee_device_1,
+      fan_mode_setting: "on",
+    },
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  )
+
+  t.is(200, status)
+
+  t.is(action_attempt.status, "pending")
+  t.is(action_attempt.action_type, "SET_FAN_MODE")
+  t.is(action_attempt.error, null)
+  t.is(action_attempt.result, null)
+})


### PR DESCRIPTION
live endpoint: https://github.com/seamapi/seam-connect/blob/main/pages/api/public/thermostats/set_fan_mode.ts

### Notable things

#### Did **not** add the deprecated `fan_mode` parameter.

Dev should just use the currently supported `fan_mode_setting`.

#### Did not add `provider.setFanMode` validation

Live checks the manufacturer name:

```ts
  const provider = getThermostatFunctionProvider(device.manufacturer_name)

  if (!provider.setFanMode) {
    throw new HttpException(400, {
      type: "set_fan_mode_not_supported",
      // TODO: Fix this the next time the file is edited.
      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
      message: `/thermostats/set_fan_mode does not support ${device.manufacturer_name} thermostats`,
    })
  }
```

Manufacturer data is missing in the fake, and seems out-of-scope for the fake anyway, where manufacturers / ids are sometimes stubbed.