### PR TITLE
feat: Use fetch to proxy response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-unused-imports": "^2.0.0",
         "get-port": "^5.1.1",
         "immer": "^9.0.21",
+        "isomorphic-fetch": "^3.0.0",
         "landlubber": "^1.0.0",
         "minisearch": "^6.1.0",
         "mkdirp": "^3.0.0",
@@ -5295,6 +5296,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -6067,6 +6078,48 @@
         "react": ">=18",
         "react-dom": ">=18",
         "zod": "^3.0.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/nofilter": {
@@ -9340,6 +9393,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.19",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
+      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==",
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-unused-imports": "^2.0.0",
     "get-port": "^5.1.1",
     "immer": "^9.0.21",
+    "isomorphic-fetch": "^3.0.0",
     "landlubber": "^1.0.0",
     "minisearch": "^6.1.0",
     "mkdirp": "^3.0.0",

--- a/src/pages/api/internal/devicedb/[...path].ts
+++ b/src/pages/api/internal/devicedb/[...path].ts
@@ -1,3 +1,5 @@
+import "isomorphic-fetch"
+
 import { z } from "zod"
 
 import { withRouteSpec } from "lib/middleware/with-route-spec.ts"

--- a/src/pages/api/internal/devicedb_image_proxy.ts
+++ b/src/pages/api/internal/devicedb_image_proxy.ts
@@ -1,9 +1,13 @@
-import axios from "axios"
 import { z } from "zod"
 
 import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
 
-const forwardedHeaders = ["content-type", "last-modified", "cache-control"]
+const forwardedHeaders = [
+  "content-type",
+  "etag",
+  "last-modified",
+  "cache-control",
+]
 
 export default withRouteSpec({
   methods: ["GET"],
@@ -17,25 +21,24 @@ export default withRouteSpec({
     return
   }
 
-  const { data, headers, status } = await axios.get("/images/view", {
-    params: {
-      image_id: query.image_id,
-    },
-    baseURL: db.devicedbConfig.url,
+  const url = new URL("images/view", db.devicedbConfig.url)
+  url.searchParams.set("image_id", query.image_id)
+  const proxyRes = await fetch(url, {
+    method: "GET",
     headers: {
       "x-vercel-protection-bypass":
         db.devicedbConfig.vercelProtectionBypassSecret,
     },
-    validateStatus: () => true,
-    responseType: "arraybuffer",
   })
+  const { status, headers } = proxyRes
+  const data = await proxyRes.arrayBuffer()
 
-  res.status(status)
-  for (const header of forwardedHeaders) {
-    if (headers[header] != null) {
-      res.setHeader(header, headers[header])
+  for (const key of forwardedHeaders) {
+    if (headers.has(key)) {
+      const value = headers.get(key)
+      if (typeof value === "string") res.setHeader(key, value)
     }
   }
 
-  res.send(data)
+  res.status(status).end(Buffer.from(data))
 })

--- a/src/pages/api/internal/devicedb_image_proxy.ts
+++ b/src/pages/api/internal/devicedb_image_proxy.ts
@@ -1,3 +1,5 @@
+import "isomorphic-fetch"
+
 import { z } from "zod"
 
 import { withRouteSpec } from "lib/middleware/with-route-spec.ts"


### PR DESCRIPTION
Axios has a known issue with vitest when running in workers. Fetch makes more sense here anyway IMO as it does not introduce a new dependency.