### PR TITLE
fix: Allow constructed URLs to include paths

### DIFF
--- a/src/pages/api/internal/devicedb/[...path].ts
+++ b/src/pages/api/internal/devicedb/[...path].ts
@@ -26,7 +26,7 @@ export default withRouteSpec({
     return
   }
 
-  const url = new URL(path.join("/"), db.devicedbConfig.url)
+  const url = new URL(`${db.devicedbConfig.url}/${path.join("/")}`)
   for (const [k, v] of Object.entries(query)) {
     if (typeof v === "string") url.searchParams.append(k, v)
   }
@@ -67,7 +67,7 @@ const replaceImageUrls = (data: Buffer, baseUrl: string): string => {
       throw new Error(`Missing image_id param in ${value}`)
     }
 
-    const proxiedUrl = new URL("/internal/devicedb_image_proxy", baseUrl)
+    const proxiedUrl = new URL(`${baseUrl}/internal/devicedb_image_proxy`)
     proxiedUrl.searchParams.set("image_id", imageId)
     return proxiedUrl.toString()
   })

--- a/src/pages/api/internal/devicedb_image_proxy.ts
+++ b/src/pages/api/internal/devicedb_image_proxy.ts
@@ -23,7 +23,7 @@ export default withRouteSpec({
     return
   }
 
-  const url = new URL("images/view", db.devicedbConfig.url)
+  const url = new URL(`${db.devicedbConfig.url}/images/view`)
   url.searchParams.set("image_id", query.image_id)
   const proxyRes = await fetch(url, {
     method: "GET",


### PR DESCRIPTION
Using the second argument is a bit of a foot gun if one needs to allow sub-paths.
