### PR TITLE
Allow passing custom id when creating connected accounts with `addConnectedAccount`

### DIFF
--- a/src/lib/database/store.ts
+++ b/src/lib/database/store.ts
@@ -218,7 +218,8 @@ const initializer = immer<Database>((set, get) => ({
   addConnectedAccount(params) {
     // @ts-expect-error  Partially implemented
     const new_connected_account: ConnectedAccount = {
-      connected_account_id: get()._getNextId("connected_account"),
+      connected_account_id:
+        params.connected_account_id ?? get()._getNextId("connected_account"),
       provider: params.provider,
       workspace_id: params.workspace_id,
       created_at: params.created_at ?? new Date().toISOString(),


### PR DESCRIPTION
Currently we pass custom id like `john_connected_account_id` when creating a connected account in the `lib/database/seed.ts` and then associate new devices with that id but `addConnectedAccount` method wasn't assigning such ids to accounts during creation so the devices were associated with a nonexistent account ids.