### PR TITLE
fix: Empty array param parsing regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "ms": "^2.1.3",
         "next": "^12.3.4",
         "nextjs-server-modules": "^4.1.1",
-        "nextlove": "^2.8.0",
+        "nextlove": "^2.8.2",
         "prettier": "^2.3.0",
         "tsup": "^7.1.0",
         "tsx": "^3.12.1",
@@ -6057,9 +6057,9 @@
       }
     },
     "node_modules/nextlove": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nextlove/-/nextlove-2.8.0.tgz",
-      "integrity": "sha512-AgFcs58rs6MBAgjjQf7qw3ybhL3/J/I8k9YYFfI/9x2K6GioJcoIQmLGtT/doYYaCoFcCscKJI+7C1/pljwilQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/nextlove/-/nextlove-2.8.2.tgz",
+      "integrity": "sha512-d6L8TCH0DUR2Tb1/XSBOJLqb/ODviUOPw4jWLzwcvNCwgH/lTFVgXLVVWJvEgkggrq3zKS0Y52A6mCLCYd7BTA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@godaddy/terminus": "^4.12.1",
         "@seamapi/fake-devicedb": "^1.0.0-rc.0",
+        "@seamapi/http": "^0.3.0",
         "@seamapi/logger": "^1.9.2",
         "@seamapi/types": "^1.26.2",
         "@tsconfig/next": "^1.0.5",
@@ -214,6 +215,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1062,6 +1075,32 @@
         "zod": "^3.21.4",
         "zustand": "^4.3.7",
         "zustand-hoist": "^1.0.0"
+      }
+    },
+    "node_modules/@seamapi/http": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/http/-/http-0.3.0.tgz",
+      "integrity": "sha512-uGjMwIW13+JAiv0Ud8HRa5Be0yKOJFbww59k/6KuTMjeYFcCXG+VbAzJId5ZQMSHPlFLQ4D2jxdMYyXeBNrmbQ==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.5.0",
+        "axios-retry": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16.13.0",
+        "npm": ">= 8.1.0"
+      },
+      "peerDependencies": {
+        "@seamapi/types": "^1.0.0",
+        "type-fest": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@seamapi/types": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@seamapi/logger": {
@@ -1989,8 +2028,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -2103,11 +2141,20 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
       "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.8.1.tgz",
+      "integrity": "sha512-4XseuArB4CEbfLRtMpUods2q8MLBvD4r8ifKgK4SP2FRgzQIPUDpzZ+cjQ/19eu3w2UpKgkJA+myEh2BYDSjqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2673,7 +2720,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3119,7 +3165,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4192,7 +4237,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -4230,7 +4274,6 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5185,6 +5228,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -5780,7 +5835,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5790,7 +5844,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6887,8 +6940,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -7186,6 +7238,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ms": "^2.1.3",
     "next": "^12.3.4",
     "nextjs-server-modules": "^4.1.1",
-    "nextlove": "^2.8.0",
+    "nextlove": "^2.8.2",
     "prettier": "^2.3.0",
     "tsup": "^7.1.0",
     "tsx": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@godaddy/terminus": "^4.12.1",
     "@seamapi/fake-devicedb": "^1.0.0-rc.0",
+    "@seamapi/http": "^0.3.0",
     "@seamapi/logger": "^1.9.2",
     "@seamapi/types": "^1.26.2",
     "@tsconfig/next": "^1.0.5",

--- a/src/lib/util/devices.ts
+++ b/src/lib/util/devices.ts
@@ -30,44 +30,54 @@ export const getDevicesWithFilter = (
   device_filters: DeviceFilters
 ): Device[] => {
   const {
-    is_managed,
     workspace_id,
+    is_managed,
     manufacturer,
     name,
     device_id,
+    device_ids,
     connected_account_id,
+    connected_account_ids,
     device_type,
+    device_types,
   } = device_filters
 
-  const device_types =
-    device_type != null
-      ? [device_type, ...(device_filters.device_types ?? [])]
-      : device_filters.device_types ?? []
-  const connected_account_ids =
-    connected_account_id != null
-      ? [connected_account_id, ...(device_filters.connected_account_ids ?? [])]
-      : device_filters.connected_account_ids ?? []
-  const device_ids =
-    device_id != null
-      ? [device_id, ...(device_filters.device_ids ?? [])]
-      : device_filters.device_ids ?? []
-
-  return db.devices.filter(
-    (d) =>
-      d.workspace_id === workspace_id &&
-      (is_managed == null ? true : d.is_managed === is_managed) &&
-      (device_ids.length === 0 ? true : device_ids.includes(d.device_id)) &&
-      (connected_account_ids.length === 0
-        ? true
-        : connected_account_ids.includes(d.connected_account_id)) &&
-      (device_types.length === 0
-        ? true
-        : device_types.includes(d.device_type)) &&
-      (manufacturer == null
-        ? true
-        : "manufacturer" in d.properties
-        ? d.properties.manufacturer === manufacturer
-        : false) &&
-      (name == null ? true : d.properties.name === name)
-  )
+  return db.devices
+    .filter((d) => d.workspace_id === workspace_id)
+    .filter((d) => {
+      if (is_managed == null) return true
+      return d.is_managed === is_managed
+    })
+    .filter((d) => {
+      if (manufacturer == null) return true
+      return d.properties.manufacturer === manufacturer
+    })
+    .filter((d) => {
+      if (name == null) return true
+      return d.properties.name === name
+    })
+    .filter((d) => {
+      if (device_id == null) return true
+      return d.device_id === device_id
+    })
+    .filter((d) => {
+      if (device_ids == null) return true
+      return device_ids.includes(d.device_id)
+    })
+    .filter((d) => {
+      if (connected_account_id == null) return true
+      return d.connected_account_id === connected_account_id
+    })
+    .filter((d) => {
+      if (connected_account_ids == null) return true
+      return connected_account_ids.includes(d.connected_account_id)
+    })
+    .filter((d) => {
+      if (device_type == null) return true
+      return d.device_type === device_type
+    })
+    .filter((d) => {
+      if (device_types == null) return true
+      return device_types.includes(d.device_type)
+    })
 }

--- a/src/pages/api/devices/list.ts
+++ b/src/pages/api/devices/list.ts
@@ -8,9 +8,9 @@ import { getManagedDevicesWithFilter } from "lib/util/devices.ts"
 export const common_params = z.object({
   device_ids: z.array(z.string()).optional(),
   connected_account_id: z.string().optional(),
-  connected_account_ids: z.array(z.string()).nonempty().optional(),
+  connected_account_ids: z.array(z.string()).optional(),
   device_type: device_type.optional(),
-  device_types: z.array(device_type).nonempty().optional(),
+  device_types: z.array(device_type).optional(),
   manufacturer: z.string().optional(),
 })
 

--- a/test/api/devices/list.test.ts
+++ b/test/api/devices/list.test.ts
@@ -67,6 +67,21 @@ test("GET /devices/list with empty device_ids", async (t: ExecutionContext) => {
   t.is(devices.length, 0)
 })
 
+test("GET /devices/list with empty connected_account_ids", async (t: ExecutionContext) => {
+  const { axios, db } = await getTestServer(t, { seed: false })
+  const seed_result = seed(db)
+
+  axios.defaults.headers.common.Authorization = `Bearer ${seed_result.seam_apikey1_token}`
+
+  const {
+    data: { devices },
+  } = await axios.post("/devices/list", {
+    data: { connected_account_ids: [] },
+  })
+
+  t.is(devices.length, 0)
+})
+
 test("GET /devices/list with simulated workspace outage", async (t: ExecutionContext) => {
   const { axios, db } = await getTestServer(t, { seed: false })
   const seed_result = seed(db)

--- a/test/api/devices/list.test.ts
+++ b/test/api/devices/list.test.ts
@@ -82,6 +82,21 @@ test("GET /devices/list with empty connected_account_ids", async (t: ExecutionCo
   t.is(devices.length, 0)
 })
 
+test("GET /devices/list with empty device_types", async (t: ExecutionContext) => {
+  const { axios, db } = await getTestServer(t, { seed: false })
+  const seed_result = seed(db)
+
+  axios.defaults.headers.common.Authorization = `Bearer ${seed_result.seam_apikey1_token}`
+
+  const {
+    data: { devices },
+  } = await axios.post("/devices/list", {
+    data: { device_types: [] },
+  })
+
+  t.is(devices.length, 0)
+})
+
 test("GET /devices/list with simulated workspace outage", async (t: ExecutionContext) => {
   const { axios, db } = await getTestServer(t, { seed: false })
   const seed_result = seed(db)

--- a/test/api/devices/list.test.ts
+++ b/test/api/devices/list.test.ts
@@ -52,6 +52,21 @@ test("GET /devices/list with filters", async (t: ExecutionContext) => {
   t.true(devices_res.data.devices.length > 0)
 })
 
+test("GET /devices/list with empty device_ids", async (t: ExecutionContext) => {
+  const { axios, db } = await getTestServer(t, { seed: false })
+  const seed_result = seed(db)
+
+  axios.defaults.headers.common.Authorization = `Bearer ${seed_result.seam_apikey1_token}`
+
+  const {
+    data: { devices },
+  } = await axios.post("/devices/list", {
+    data: { device_ids: [] },
+  })
+
+  t.is(devices.length, 0)
+})
+
 test("GET /devices/list with simulated workspace outage", async (t: ExecutionContext) => {
   const { axios, db } = await getTestServer(t, { seed: false })
   const seed_result = seed(db)

--- a/test/api/devices/list.test.ts
+++ b/test/api/devices/list.test.ts
@@ -61,7 +61,7 @@ test("GET /devices/list with empty device_ids", async (t: ExecutionContext) => {
   const {
     data: { devices },
   } = await axios.post("/devices/list", {
-    data: { device_ids: [] },
+    device_ids: [],
   })
 
   t.is(devices.length, 0)
@@ -76,7 +76,7 @@ test("GET /devices/list with empty connected_account_ids", async (t: ExecutionCo
   const {
     data: { devices },
   } = await axios.post("/devices/list", {
-    data: { connected_account_ids: [] },
+    connected_account_ids: [],
   })
 
   t.is(devices.length, 0)
@@ -91,7 +91,7 @@ test("GET /devices/list with empty device_types", async (t: ExecutionContext) =>
   const {
     data: { devices },
   } = await axios.post("/devices/list", {
-    data: { device_types: [] },
+    device_types: [],
   })
 
   t.is(devices.length, 0)

--- a/test/api/events/list.test.ts
+++ b/test/api/events/list.test.ts
@@ -95,7 +95,7 @@ test("GET /events/list", async (t: ExecutionContext) => {
       Authorization: `Bearer ${seed.ws2.cst}`,
     },
   })
-  t.is(events_list_request.data.events.length, 0)
+  t.is(events_list_request.data.events.length, 1)
 
   // Test 200 response (empty device_ids)
   events_list_request = await axios.get("/events/list", {

--- a/test/api/events/list.test.ts
+++ b/test/api/events/list.test.ts
@@ -85,6 +85,30 @@ test("GET /events/list", async (t: ExecutionContext) => {
   t.true(events_list_request.data.events.length === 1)
   t.is(events_list_request.data.events[0]?.device_id, device_id)
 
+  // Test 200 response (device_ids)
+  events_list_request = await axios.get("/events/list", {
+    params: {
+      device_ids: [device_id],
+      since: date_before_event_happened,
+    },
+    headers: {
+      Authorization: `Bearer ${seed.ws2.cst}`,
+    },
+  })
+  t.is(events_list_request.data.events.length, 0)
+
+  // Test 200 response (empty device_ids)
+  events_list_request = await axios.get("/events/list", {
+    params: {
+      device_ids: [],
+      since: date_before_event_happened,
+    },
+    headers: {
+      Authorization: `Bearer ${seed.ws2.cst}`,
+    },
+  })
+  t.is(events_list_request.data.events.length, 0)
+
   // Test 200 response (access_code_ids)
   events_list_request = await axios.get("/events/list", {
     params: {
@@ -100,6 +124,18 @@ test("GET /events/list", async (t: ExecutionContext) => {
     events_list_request.data.events[0]?.access_code_id,
     created_access_code.access_code_id
   )
+
+  // Test 200 response (empty access_code_ids)
+  events_list_request = await axios.get("/events/list", {
+    params: {
+      access_code_ids: [],
+      since: date_before_event_happened,
+    },
+    headers: {
+      Authorization: `Bearer ${seed.ws2.cst}`,
+    },
+  })
+  t.is(events_list_request.data.events.length, 0)
 
   // Test 200 response (event_type)
   events_list_request = await axios.get("/events/list", {

--- a/test/fixtures/get-test-server.ts
+++ b/test/fixtures/get-test-server.ts
@@ -1,4 +1,5 @@
 import { createFake as createFakeDevicedb } from "@seamapi/fake-devicedb"
+import { paramsSerializer } from "@seamapi/http/connect"
 import type { ExecutionContext } from "ava"
 import type { Axios } from "axios"
 import type { NextApiRequest } from "next"
@@ -51,6 +52,8 @@ export const getTestServer = async <TSeed extends boolean>(
     ],
   })
   baseUrl = fixture.serverURL
+
+  fixture.axios.defaults.paramsSerializer = paramsSerializer
 
   return {
     ...fixture,


### PR DESCRIPTION
When array params are passed to the API as an empty array, the real API behavior would return no results, e.g., the logic is always `filter(r => r_ids.includes(r.id))`, the length of `r_ids` is irrelevant. 