### PR TITLE
fix: Bypass terminus if no signals are passed

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -48,6 +48,8 @@ export async function startServer(
     ],
   })
 
+  if (signals.length === 0) return new Server({ server, port })
+
   return new Server({
     server: createTerminus(server, {
       onShutdown: async () => {


### PR DESCRIPTION
This is only used in Docker of if the server is run as the main process entrypoint. I am seeing possible issues with Node 20 and latest AVA. No reason to use this when controlled directly.