### PR TITLE
feat: visionline simulate unlock

### DIFF
--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -22,6 +22,7 @@ import type { RecursivePartial } from "lib/util/type-helpers.ts"
 import type {
   AssaAbloyCard,
   CredentialService,
+  SimulatedEvent,
 } from "lib/zod/assa_abloy_credential_service.ts"
 import type { ClimateSetting } from "lib/zod/climate_setting.ts"
 import type { Endpoint } from "lib/zod/endpoints.ts"
@@ -53,6 +54,7 @@ export interface DatabaseState {
     string,
     { workspace_id: string; routes: Array<keyof Routes> } | undefined
   >
+  simulatedEvents: Record<string, SimulatedEvent[]>
   phone_invitations: PhoneInvitation[]
   phone_sdk_installations: PhoneSdkInstallation[]
   user_identities: UserIdentity[]
@@ -108,6 +110,9 @@ export interface DatabaseMethods {
     is_active: boolean
   }) => Endpoint
   addAssaAbloyCard: (params: { endpoint_id: string }) => AssaAbloyCard
+  addSimulatedReaderEvent: (
+    event: Omit<SimulatedEvent, "timestamp">,
+  ) => SimulatedEvent
   addEnrollmentAutomation: (params: {
     enrollment_automation_id?: string
     workspace_id: WorkspaceId

--- a/src/lib/zod/assa_abloy_credential_service.ts
+++ b/src/lib/zod/assa_abloy_credential_service.ts
@@ -80,3 +80,12 @@ export const card = z.object({
 })
 
 export type AssaAbloyCard = z.infer<typeof card>
+
+export const simulated_event = z.object({
+  simulated_event_type: z.enum(["tap"]),
+  reader_id: z.number(),
+  card_number: z.string(),
+  timestamp: z.string(),
+})
+
+export type SimulatedEvent = z.infer<typeof simulated_event>

--- a/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/list_events.ts
+++ b/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/list_events.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+
+import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
+import { simulated_event } from "lib/zod/assa_abloy_credential_service.ts"
+
+export default withRouteSpec({
+  auth: "none",
+  methods: ["GET", "POST"],
+  commonParams: z.object({
+    reader_id: z.coerce.number(),
+  }),
+  jsonResponse: z.object({
+    events: z.array(simulated_event),
+  }),
+} as const)(async (req, res) => {
+  const {
+    commonParams: { reader_id },
+  } = req
+
+  const events = req.db.simulatedEvents[reader_id] ?? []
+
+  res.json({
+    events,
+  })
+})

--- a/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock.ts
+++ b/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock.ts
@@ -44,6 +44,7 @@ export default withRouteSpec({
     return
   }
 
+  // Only door with reader_id of 1 exists. Can be changed in `addAssaAbloyCard`
   const is_allowed =
     card.doorOperations.some((d) => d.doors.includes(reader_id.toString())) &&
     !card.cancelled &&

--- a/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock.ts
+++ b/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock.ts
@@ -1,0 +1,67 @@
+import { z } from "zod"
+
+import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
+
+export default withRouteSpec({
+  auth: "none",
+  methods: ["POST"],
+  jsonBody: z.object({
+    reader_id: z.number(),
+    tap: z.boolean().optional(),
+    credential: z.object({
+      format: z.object({
+        name: z.string(),
+      }),
+      card_number: z.string(),
+      facility_code: z.string().optional(),
+    }),
+  }),
+  jsonResponse: z.object({}),
+} as const)(async (req, res) => {
+  const {
+    body: { reader_id, credential, tap },
+  } = req
+
+  if (tap != null) {
+    res.status(501).send("Only tap to unlock is implemented")
+    return
+  }
+
+  const { format, card_number } = credential
+
+  const card = req.db.assa_abloy_cards.find(
+    (card) => card.id === card_number && card.format === format.name,
+  )
+
+  if (card == null) {
+    res.status(404).json({
+      stauts: 404,
+      code: 40401,
+      resource: null,
+      message: "The resource does not exist.",
+      developerMessage: "The resource does not exist.",
+    })
+    return
+  }
+
+  const is_allowed =
+    card.doorOperations.some((d) => d.doors.includes(reader_id.toString())) &&
+    !card.cancelled &&
+    !card.notIssued &&
+    !card.expired &&
+    !card.discarded
+
+  if (!is_allowed) {
+    res.status(403).json({
+      message: "Access denied",
+    })
+    return
+  }
+
+  req.db.addSimulatedReaderEvent({
+    reader_id,
+    simulated_event_type: "tap",
+    card_number,
+  })
+  res.status(200).json({})
+})

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -2467,6 +2467,46 @@ export type Routes = {
       ok: boolean
     }
   }
+  "/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/list_events": {
+    route: "/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/list_events"
+    method: "GET" | "POST"
+    queryParams: {}
+    jsonBody: {}
+    commonParams: {
+      reader_id: number
+    }
+    formData: {}
+    jsonResponse: {
+      events: {
+        simulated_event_type: "tap"
+        reader_id: number
+        card_number: string
+        timestamp: string
+      }[]
+      ok: boolean
+    }
+  }
+  "/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock": {
+    route: "/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock"
+    method: "POST"
+    queryParams: {}
+    jsonBody: {
+      reader_id: number
+      tap?: boolean | undefined
+      credential: {
+        format: {
+          name: string
+        }
+        card_number: string
+        facility_code?: string | undefined
+      }
+    }
+    commonParams: {}
+    formData: {}
+    jsonResponse: {
+      ok: boolean
+    }
+  }
   "/internal/tlmtry": {
     route: "/internal/tlmtry"
     method: "POST"

--- a/test/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock.test.ts
+++ b/test/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/simulate/readers/unlock.test.ts
@@ -1,0 +1,115 @@
+import test from "ava"
+
+import { getTestServer } from "fixtures/get-test-server.ts"
+import { seed } from "lib/database/seed.ts"
+
+test("POST /api/internal/sandbox/:workspace_id/assa_abloy/_fake/simulate/readers/unlock", async (t) => {
+  const { axios, db } = await getTestServer(t, { seed: false })
+  const { seam_cst1_token } = seed(db)
+
+  const client_session = db.getClientSession(seam_cst1_token)
+
+  if (client_session === undefined) {
+    t.fail("Client session not found")
+    return
+  }
+
+  axios.defaults.headers.common.Authorization = `Bearer ${seam_cst1_token}`
+
+  const ext_sdk_installation_id = "ext_sdk_installation_id"
+
+  const {
+    data: { invitations },
+  } = await axios.post("/internal/phone/user_identities/create_invitations", {
+    custom_sdk_installation_id: ext_sdk_installation_id,
+    phone_os: "android",
+  })
+
+  const {
+    data: { invitation },
+  } = await axios.post("/internal/phone/user_identities/get_invitation", {
+    custom_sdk_installation_id: ext_sdk_installation_id,
+    invitation_id: invitations[0]?.invitation_id ?? "",
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain, @typescript-eslint/no-non-null-assertion
+    invitation_type: invitations[0]?.invitation_type!,
+  })
+
+  const invitation_code = invitation.invitation_code ?? ""
+  if (invitation_code === "") {
+    t.fail("Failed to create invite")
+  }
+
+  const {
+    data: { endpoint },
+  } = await axios.post(
+    `/internal/sandbox/test/assa_abloy/_fake/redeem_invite_code`,
+    {
+      invite_code: invitation_code,
+      endpoint_details: {
+        application_version: "",
+        ble_capability: true,
+        device_manufacturer: "",
+        device_model: "",
+        hce_capability: true,
+        nfc_capability: true,
+        os_version: "",
+        seos_applet_version: "",
+      },
+    },
+  )
+
+  t.truthy(endpoint.invite_code)
+
+  const {
+    data: { cards },
+  } = await axios.post(
+    "/internal/sandbox/test/assa_abloy/_fake/load_credentials",
+    {
+      endpoint_id: endpoint.endpoint_id,
+    },
+  )
+
+  const card = cards[0]
+
+  if (card == null) {
+    t.fail("No card credentials found")
+    return
+  }
+
+  const {
+    data: { events: simulated_unlock_events },
+  } = await axios.get(
+    "/internal/sandbox/test/assa_abloy/_fake/simulate/readers/list_events",
+    {
+      params: {
+        reader_id: 1,
+      },
+    },
+  )
+
+  t.is(simulated_unlock_events.length, 0)
+
+  await axios.post(
+    "/internal/sandbox/test/assa_abloy/_fake/simulate/readers/unlock",
+    {
+      reader_id: 1,
+      credential: {
+        format: { name: card.format },
+        card_number: card.id,
+      },
+    },
+  )
+
+  const {
+    data: { events: single_unlock },
+  } = await axios.get(
+    "/internal/sandbox/test/assa_abloy/_fake/simulate/readers/list_events",
+    {
+      params: {
+        reader_id: 1,
+      },
+    },
+  )
+
+  t.is(single_unlock.length, 1)
+})


### PR DESCRIPTION
Closes https://github.com/seamapi/fake-seam-connect/issues/136

simulate tap to unlock visionline reader

Using dummy data right now since none of the acs fake endpoints are implemented. Just to get by for mobilesdk testing