### PR TITLE
feat: activate assa abloy endpoint

### DIFF
--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -107,8 +107,11 @@ export interface DatabaseMethods {
   addEndpoint: (params: {
     assa_abloy_credential_service_id: string
     invitation_id: string
-    is_active: boolean
   }) => Endpoint
+  activateEndpoint: (params: {
+    endpoint_id: string
+    invitation_code: string
+  }) => void
   addAssaAbloyCard: (params: { endpoint_id: string }) => AssaAbloyCard
   addSimulatedReaderEvent: (
     event: Omit<SimulatedEvent, "timestamp">,

--- a/src/lib/zod/invitations.ts
+++ b/src/lib/zod/invitations.ts
@@ -16,6 +16,7 @@ export const invitation_schema_assa_abloy = z.object({
   invitation_type: z.literal("assa_abloy_credential_service"),
   invitation_id: z.string(),
   invitation_code: z.string().optional(),
+  ext_assa_abloy_cs_endpoint_id: z.string().optional(),
 })
 
 export const invitation_schema = z.discriminatedUnion("invitation_type", [

--- a/src/pages/api/internal/phone/user_identities/get_invitation.ts
+++ b/src/pages/api/internal/phone/user_identities/get_invitation.ts
@@ -64,11 +64,18 @@ export default withRouteSpec({
     })
   }
 
+  const endpoint = req.db.addEndpoint({
+    assa_abloy_credential_service_id:
+      invitation.assa_abloy_credential_service_id ?? "",
+    invitation_id: invitation.invitation_id,
+  })
+
   res.status(200).json({
     invitation: {
       invitation_id: invitation.invitation_id,
       invitation_type: invitation.invitation_type,
       invitation_code: invitation.invitation_code,
+      ext_assa_abloy_cs_endpoint_id: endpoint.endpoint_id,
     },
   })
 })

--- a/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/redeem_invite_code.ts
+++ b/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/redeem_invite_code.ts
@@ -48,15 +48,10 @@ export default withRouteSpec({
     endpoint_id: invitation_endpoint.endpoint_id,
     invitation_code: invitation.invitation_code,
   })
-  const endpoint = req.db.addEndpoint({
-    assa_abloy_credential_service_id:
-      invitation?.assa_abloy_credential_service_id,
-    invitation_id: invitation.invitation_id,
-  })
 
   res.status(200).json({
     endpoint: {
-      endpoint_id: endpoint.endpoint_id,
+      endpoint_id: invitation_endpoint.endpoint_id,
       status: "ACTIVE",
       invite_code: invitation.invitation_code,
     },

--- a/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/redeem_invite_code.ts
+++ b/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/redeem_invite_code.ts
@@ -30,8 +30,6 @@ export default withRouteSpec({
     throw new Error("Invalid invitation!")
   }
 
-  req.db.endpoints.find((endpoint) => endpoint)
-
   const invitation_endpoint = req.db.endpoints.find(
     (endpoint) =>
       endpoint.endpoint_type === "assa_abloy_credential_service" &&

--- a/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/redeem_invite_code.ts
+++ b/src/pages/api/internal/sandbox/[workspace_id]/assa_abloy/_fake/redeem_invite_code.ts
@@ -30,11 +30,28 @@ export default withRouteSpec({
     throw new Error("Invalid invitation!")
   }
 
+  req.db.endpoints.find((endpoint) => endpoint)
+
+  const invitation_endpoint = req.db.endpoints.find(
+    (endpoint) =>
+      endpoint.endpoint_type === "assa_abloy_credential_service" &&
+      endpoint.invitation_id === invitation.invitation_id,
+  )
+
+  if (invitation_endpoint == null) {
+    throw new Error(
+      `No endpoint found with invitation id: ${invitation.invitation_id}`,
+    )
+  }
+
+  req.db.activateEndpoint({
+    endpoint_id: invitation_endpoint.endpoint_id,
+    invitation_code: invitation.invitation_code,
+  })
   const endpoint = req.db.addEndpoint({
     assa_abloy_credential_service_id:
       invitation?.assa_abloy_credential_service_id,
     invitation_id: invitation.invitation_id,
-    is_active: true,
   })
 
   res.status(200).json({

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -2257,6 +2257,7 @@ export type Routes = {
         | {
             invitation_type: "assa_abloy_credential_service"
             invitation_id: string
+            ext_assa_abloy_cs_endpoint_id?: string | undefined
           }
         | {
             invitation_type: "hid_credential_manager"
@@ -2290,6 +2291,7 @@ export type Routes = {
             invitation_type: "assa_abloy_credential_service"
             invitation_id: string
             invitation_code?: string | undefined
+            ext_assa_abloy_cs_endpoint_id?: string | undefined
           }
       ok: boolean
     }


### PR DESCRIPTION
Assa abloy endpoint is created when an invitation is first created, it gets activated when the invitation code is redeemed. This PR implements an `activateEndpoint` function and defaults `addEndpoint().is_active` to be false 