### PR TITLE
include seos tsm id in response

### DIFF
--- a/src/pages/api/internal/sandbox/[workspace_id]/visionline/_fake/redeem_invite_code.ts
+++ b/src/pages/api/internal/sandbox/[workspace_id]/visionline/_fake/redeem_invite_code.ts
@@ -52,6 +52,10 @@ export default withRouteSpec({
       endpoint_id: invitation_endpoint.endpoint_id,
       status: "ACTIVE",
       invite_code: invitation.invitation_code,
+      details: {
+        ...req.body.endpoint_details,
+        seos_tsm_endpoint_id: 1234,
+      },
     },
   })
 })

--- a/test/api/internal/sandbox/[workspace_id]/visionline/_fake/redeem_invite_code.test.ts
+++ b/test/api/internal/sandbox/[workspace_id]/visionline/_fake/redeem_invite_code.test.ts
@@ -62,4 +62,5 @@ test("GET /internal/sandbox/[workspace_id]/visionline/_fake/redeem_invite_code",
 
   t.truthy(endpoint.endpoint_id)
   t.truthy(endpoint.invite_code)
+  t.is(endpoint.details?.seos_tsm_endpoint_id, 1234)
 })


### PR DESCRIPTION
This is supposed to be a non-nullable field in the SDK, so it should definitely be returned

cc @ethanplee14 