### PR TITLE
fix: remove invitation id from assa abloy endpoint

### DIFF
--- a/src/lib/zod/endpoints.ts
+++ b/src/lib/zod/endpoints.ts
@@ -8,14 +8,24 @@ export const endpoint_schema_hid = z.object({
 export const endpoint_schema_assa_abloy = z.object({
   endpoint_type: z.literal("assa_abloy_credential_service"),
   endpoint_id: z.string(),
+  invitation_id: z.string(),
   is_active: z.boolean(),
   seos_tsm_endpoint_id: z.number().nullable(),
   assa_abloy_credential_service_id: z.string(),
 })
+
+export const public_endpoint_schema_assa_abloy =
+  endpoint_schema_assa_abloy.omit({ invitation_id: true })
 
 export const endpoint_schema = z.discriminatedUnion("endpoint_type", [
   endpoint_schema_hid,
   endpoint_schema_assa_abloy,
 ])
 
+export const public_endpoint_schema = z.discriminatedUnion("endpoint_type", [
+  endpoint_schema_hid,
+  public_endpoint_schema_assa_abloy,
+])
+
 export type Endpoint = z.infer<typeof endpoint_schema>
+export type PublicEndpoint = z.infer<typeof public_endpoint_schema>

--- a/src/lib/zod/endpoints.ts
+++ b/src/lib/zod/endpoints.ts
@@ -8,7 +8,6 @@ export const endpoint_schema_hid = z.object({
 export const endpoint_schema_assa_abloy = z.object({
   endpoint_type: z.literal("assa_abloy_credential_service"),
   endpoint_id: z.string(),
-  invitation_id: z.string(),
   is_active: z.boolean(),
   seos_tsm_endpoint_id: z.number().nullable(),
   assa_abloy_credential_service_id: z.string(),

--- a/src/pages/api/internal/phone/user_identities/list_endpoints.ts
+++ b/src/pages/api/internal/phone/user_identities/list_endpoints.ts
@@ -2,7 +2,7 @@ import { NotFoundException } from "nextlove"
 import { z } from "zod"
 
 import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
-import { endpoint_schema } from "lib/zod/endpoints.ts"
+import { public_endpoint_schema } from "lib/zod/endpoints.ts"
 
 export default withRouteSpec({
   auth: "client_session",
@@ -11,7 +11,7 @@ export default withRouteSpec({
     custom_sdk_installation_id: z.string(),
   }),
   jsonResponse: z.object({
-    endpoints: z.array(endpoint_schema),
+    endpoints: z.array(public_endpoint_schema),
   }),
 } as const)(async (req, res) => {
   const { custom_sdk_installation_id } = req.body
@@ -30,10 +30,16 @@ export default withRouteSpec({
     })
   }
 
-  const endpoints = req.db.getState().getEndpoints({
-    client_session_id,
-    phone_sdk_installation_id: installation.phone_sdk_installation_id,
-  })
+  const endpoints = req.db
+    .getState()
+    .getEndpoints({
+      client_session_id,
+      phone_sdk_installation_id: installation.phone_sdk_installation_id,
+    })
+    .map((endpoint) => ({
+      ...endpoint,
+      invitation_id: undefined,
+    }))
 
   res.status(200).json({
     endpoints,

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -2358,7 +2358,6 @@ export type Routes = {
         | {
             endpoint_type: "assa_abloy_credential_service"
             endpoint_id: string
-            invitation_id: string
             is_active: boolean
             seos_tsm_endpoint_id: number | null
             assa_abloy_credential_service_id: string

--- a/test/api/internal/phone/user_identities/list_endpoints.test.ts
+++ b/test/api/internal/phone/user_identities/list_endpoints.test.ts
@@ -69,4 +69,6 @@ test("POST /internal/phone/user_identities/list_endpoints", async (t) => {
     endpoint_id: endpoint.endpoint_id,
     is_active: endpoint.status === "ACTIVE",
   })
+
+  t.falsy((endpoints[0] as any).invitation_id)
 })


### PR DESCRIPTION
Assa abloy endpoint doesn't have an invitation id in connect:

https://github.com/seamapi/seam-connect/blob/b1fb61c5cbde341fd22dc9aec548d24085d62e6b/lib/acs/types.ts#L62