### PR TITLE
`/workspaces/create`: rename `workspace_name` to `name` param

### DIFF
--- a/src/pages/api/workspaces/create.ts
+++ b/src/pages/api/workspaces/create.ts
@@ -7,17 +7,19 @@ import { jsonBody } from "pages/api/internal/workspaces/create.ts"
 export const route_spec = {
   methods: ["POST"],
   auth: "access_token",
-  jsonBody,
+  jsonBody: jsonBody
+    .omit({ workspace_name: true })
+    .extend({ name: z.string() }),
   jsonResponse: z.object({
     workspace,
   }),
 } as const
 
 export default withRouteSpec(route_spec)(async (req, res) => {
-  const { workspace_name, connect_partner_name, is_sandbox } = req.body
+  const { name, connect_partner_name, is_sandbox } = req.body
 
   const workspace = req.db.addWorkspace({
-    name: workspace_name,
+    name,
     connect_partner_name,
     is_sandbox,
   })

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -4998,11 +4998,11 @@ export type Routes = {
     method: "POST"
     queryParams: {}
     jsonBody: {
-      workspace_name: string
       connect_partner_name: string
       is_sandbox: boolean
       webview_primary_button_color?: string | undefined
       webview_logo_shape?: ("circle" | "square") | undefined
+      name: string
     }
     commonParams: {}
     formData: {}

--- a/test/api/workspaces/create.test.ts
+++ b/test/api/workspaces/create.test.ts
@@ -14,7 +14,7 @@ test("POST /workspaces/create", async (t: ExecutionContext) => {
     {
       connect_partner_name: "Test",
       is_sandbox: true,
-      workspace_name: "Test",
+      name: "Test",
     },
     {
       headers: {


### PR DESCRIPTION
It seems a bit unusual that the internal and public /workspaces/create endpoints differ regarding this name parameter, but that’s currently the case with seam-connect. For now, I’m aligning with this to ensure our Python SDK tests pass. We can look into harmonizing these endpoints on the seam-connect side as a future improvement.