### PR TITLE
fix: lock service codes as string instead of numbers

### DIFF
--- a/src/pages/api/internal/phone/visionline/list_lock_service_codes.ts
+++ b/src/pages/api/internal/phone/visionline/list_lock_service_codes.ts
@@ -8,13 +8,15 @@ export default withRouteSpec({
   commonParams: z.object({}),
   jsonResponse: z.object({
     list_lock_service_codes_response: z.object({
-      lock_service_codes: z.array(z.number().int()),
+      lock_service_codes: z.array(
+        z.string().regex(/^\d+$/, "Lock service codes must be integer strings"),
+      ),
     }),
   }),
 } as const)(async (_, res) => {
   res.status(200).json({
     list_lock_service_codes_response: {
-      lock_service_codes: [1],
+      lock_service_codes: ["1"],
     },
   })
 })

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -2864,7 +2864,7 @@ export type Routes = {
     formData: {}
     jsonResponse: {
       list_lock_service_codes_response: {
-        lock_service_codes: number[]
+        lock_service_codes: string[]
       }
       ok: boolean
     }

--- a/test/api/internal/phone/visionline/list_lock_service_codes.test.ts
+++ b/test/api/internal/phone/visionline/list_lock_service_codes.test.ts
@@ -22,5 +22,5 @@ test("POST /internal/phone/visionline/list_lock_service_codes", async (t) => {
   )
 
   t.is(status, 200)
-  t.deepEqual(data.list_lock_service_codes_response.lock_service_codes, [1])
+  t.deepEqual(data.list_lock_service_codes_response.lock_service_codes, ["1"])
 })


### PR DESCRIPTION
we changed lock services codes to be an array of strings instead of numbers