### PR TITLE
feat: Add `company_name` prop to `workspace` resource

### DIFF
--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -84,6 +84,7 @@ export interface DatabaseMethods {
     workspace_id?: string
     is_sandbox?: boolean
     connect_partner_name?: string
+    company_name?: string
   }) => Workspace
   resetSandboxWorkspace: (workspace_id: string) => void
   addApiKey: (params: {

--- a/src/lib/database/store.ts
+++ b/src/lib/database/store.ts
@@ -133,6 +133,10 @@ const initializer = immer<Database>((set, get) => ({
       created_at: params.created_at ?? new Date().toISOString(),
       is_sandbox: params.is_sandbox ?? false,
       connect_partner_name: params.connect_partner_name ?? null,
+      company_name:
+        params.company_name ??
+        params.connect_partner_name ??
+        "Fake Company Name",
     }
     set({
       workspaces: [...get().workspaces, new_workspace],

--- a/src/lib/zod/workspace.ts
+++ b/src/lib/zod/workspace.ts
@@ -6,7 +6,11 @@ export const workspace = z.object({
   publishable_key: z.string(),
   created_at: z.string(),
   is_sandbox: z.boolean(),
-  connect_partner_name: z.string().nullable(),
+  company_name: z.string(),
+  connect_partner_name: z
+    .string()
+    .nullable()
+    .describe("deprecated: use company_name"),
 })
 
 export type Workspace = z.infer<typeof workspace>

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -3058,6 +3058,8 @@ export type Routes = {
         publishable_key: string
         created_at: string
         is_sandbox: boolean
+        company_name: string
+        /** deprecated: use company_name */
         connect_partner_name: string | null
       }
       ok: boolean
@@ -5066,6 +5068,8 @@ export type Routes = {
         publishable_key: string
         created_at: string
         is_sandbox: boolean
+        company_name: string
+        /** deprecated: use company_name */
         connect_partner_name: string | null
       }
       ok: boolean
@@ -5085,6 +5089,8 @@ export type Routes = {
         publishable_key: string
         created_at: string
         is_sandbox: boolean
+        company_name: string
+        /** deprecated: use company_name */
         connect_partner_name: string | null
       }
       ok: boolean
@@ -5104,6 +5110,8 @@ export type Routes = {
         publishable_key: string
         created_at: string
         is_sandbox: boolean
+        company_name: string
+        /** deprecated: use company_name */
         connect_partner_name: string | null
       }[]
       ok: boolean

--- a/test/api/workspaces/get.test.ts
+++ b/test/api/workspaces/get.test.ts
@@ -14,5 +14,6 @@ test("GET /workspaces/get", async (t: ExecutionContext) => {
   })
 
   t.truthy(workspace)
+  t.truthy(workspace.company_name)
   t.is(workspace.workspace_id, seed.ws2.workspace_id)
 })


### PR DESCRIPTION
This PR adds `workspace.company_name` to fix PHP SDK tests that are failing because of this missing property.