### PR TITLE
feat(bridge): add /regenerate_pairing_code endpoint

### DIFF
--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -110,6 +110,10 @@ export interface DatabaseMethods {
   addBridgeClientSession: (
     params: Partial<BridgeClientSession>,
   ) => BridgeClientSession
+  updateBridgeClientSession: (params: {
+    bridge_client_session_id: string
+    pairing_code_expires_at?: string
+  }) => void
   addUserIdentity: (params: {
     workspace_id: WorkspaceId
     user_identity_id?: string

--- a/src/lib/database/store.ts
+++ b/src/lib/database/store.ts
@@ -326,6 +326,20 @@ const initializer = immer<Database>((set, get) => ({
     return bridge_client_session
   },
 
+  updateBridgeClientSession(params) {
+    set({
+      bridge_client_sessions: get().bridge_client_sessions.map((bcs) => {
+        if (bcs.bridge_client_session_id === params.bridge_client_session_id) {
+          return {
+            ...bcs,
+            ...params,
+          }
+        }
+        return bcs
+      }),
+    })
+  },
+
   addUserIdentity(params) {
     const user_identity_id = params.user_identity_id ?? get()._getNextId("uid")
     const new_user_identity: UserIdentity = {

--- a/src/pages/api/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code.ts
+++ b/src/pages/api/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code.ts
@@ -1,0 +1,45 @@
+import { NotFoundException } from "nextlove"
+import { z } from "zod"
+
+import { withRouteSpec } from "lib/middleware/index.ts"
+
+import { bridge_client_session } from "lib/zod/bridge_client_session.ts"
+
+export default withRouteSpec({
+  auth: ["bridge_client_session"],
+  methods: ["POST"],
+  jsonResponse: z.object({
+    bridge_client_session,
+  }),
+} as const)(async (req, res) => {
+  const { db, auth } = req
+
+  const pairing_code_expires_at = new Date(
+    new Date().getTime() + 3 * 60 * 1000,
+  ).toISOString()
+
+  const bridge_client_session = db.bridge_client_sessions.find(
+    (bridge_client_session) =>
+      bridge_client_session.bridge_client_session_id ===
+      auth.bridge_client_session.bridge_client_session_id,
+  )
+
+  if (bridge_client_session == null) {
+    throw new NotFoundException({
+      type: "bridge_client_session_not_found",
+      message: "Bridge client session not found",
+    })
+  }
+
+  db.updateBridgeClientSession({
+    bridge_client_session_id: bridge_client_session.bridge_client_session_id,
+    pairing_code_expires_at,
+  })
+
+  res.status(200).json({
+    bridge_client_session: {
+      ...bridge_client_session,
+      pairing_code_expires_at,
+    },
+  })
+})

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -4471,6 +4471,29 @@ export type Routes = {
       ok: boolean
     }
   }
+  "/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code": {
+    route: "/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code"
+    method: "POST"
+    queryParams: {}
+    jsonBody: {}
+    commonParams: {}
+    formData: {}
+    jsonResponse: {
+      bridge_client_session: {
+        created_at: string
+        bridge_client_session_id: string
+        bridge_client_session_token: string
+        pairing_code: string
+        pairing_code_expires_at: string
+        tailscale_hostname: string
+        tailscale_auth_key: string[]
+        bridge_client_name: string
+        bridge_client_time_zone: string
+        bridge_client_machine_identifier_key: string
+      }
+      ok: boolean
+    }
+  }
   "/thermostats/cool": {
     route: "/thermostats/cool"
     method: "GET" | "POST"

--- a/test/api/bridge/v1/bridge_client_sessions/regenerate_pairing_code.test.ts
+++ b/test/api/bridge/v1/bridge_client_sessions/regenerate_pairing_code.test.ts
@@ -1,0 +1,32 @@
+import test, { type ExecutionContext } from "ava"
+
+import { getTestServer } from "fixtures/get-test-server.ts"
+
+test("POST /bridge/v1/bridge_client_sessions/regenerate_pairing_code", async (t: ExecutionContext) => {
+  const { axios, seed } = await getTestServer(t)
+
+  const {
+    data: { bridge_client_session },
+  } = await axios.get("/seam/bridge/v1/bridge_client_sessions/get", {
+    headers: {
+      Authorization: `Bearer ${seed.bridge_client_session.bridge_client_session_token}`,
+    },
+  })
+
+  const {
+    data: { bridge_client_session: updated_bridge_client_session },
+  } = await axios.post(
+    "/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code",
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${seed.bridge_client_session.bridge_client_session_token}`,
+      },
+    },
+  )
+
+  t.false(
+    updated_bridge_client_session.pairing_code_expires_at ===
+      bridge_client_session.pairing_code_expires_at,
+  )
+})


### PR DESCRIPTION
Closes https://linear.app/seam/issue/ACS-476/implement-seambridgev1bridge-client-sessions-endpoints-in-fake-seam