### PR TITLE
fix(Bridge Client Session): randomize pairing_code

### DIFF
--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -112,6 +112,7 @@ export interface DatabaseMethods {
   ) => BridgeClientSession
   updateBridgeClientSession: (params: {
     bridge_client_session_id: string
+    pairing_code?: string
     pairing_code_expires_at?: string
   }) => void
   addUserIdentity: (params: {

--- a/src/lib/database/store.ts
+++ b/src/lib/database/store.ts
@@ -306,7 +306,7 @@ const initializer = immer<Database>((set, get) => ({
       created_at: new Date().toISOString(),
       bridge_client_session_id,
       bridge_client_session_token: `${bridge_client_session_id}_token`,
-      pairing_code: "123456",
+      pairing_code: Math.floor(100000 + Math.random() * 900000).toString(),
       pairing_code_expires_at: new Date().toISOString(),
       tailscale_hostname: `${bridge_client_session_id}_tailscale_host`,
       tailscale_auth_key: [`${bridge_client_session_id}_tailscale_auth`],

--- a/src/pages/api/seam/bridge/v1/bridge_client_sessions/create.ts
+++ b/src/pages/api/seam/bridge/v1/bridge_client_sessions/create.ts
@@ -31,7 +31,7 @@ export default withRouteSpec({
   } = body
 
   const bridge_client_session_token = `${bridge_client_name}_token`
-  const pairing_code = "123456"
+  const pairing_code = Math.floor(100000 + Math.random() * 900000).toString()
 
   const pairing_code_expires_at = new Date(
     new Date().getTime() + 3 * 60 * 1000,

--- a/src/pages/api/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code.ts
+++ b/src/pages/api/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code.ts
@@ -31,14 +31,18 @@ export default withRouteSpec({
     })
   }
 
+  const pairing_code = Math.floor(100000 + Math.random() * 900000).toString()
+
   db.updateBridgeClientSession({
     bridge_client_session_id: bridge_client_session.bridge_client_session_id,
+    pairing_code,
     pairing_code_expires_at,
   })
 
   res.status(200).json({
     bridge_client_session: {
       ...bridge_client_session,
+      pairing_code,
       pairing_code_expires_at,
     },
   })

--- a/test/api/bridge/v1/bridge_client_sessions/regenerate_pairing_code.test.ts
+++ b/test/api/bridge/v1/bridge_client_sessions/regenerate_pairing_code.test.ts
@@ -26,7 +26,7 @@ test("POST /bridge/v1/bridge_client_sessions/regenerate_pairing_code", async (t:
   )
 
   t.false(
-    updated_bridge_client_session.pairing_code_expires_at ===
-      bridge_client_session.pairing_code_expires_at,
+    updated_bridge_client_session.pairing_code ===
+      bridge_client_session.pairing_code,
   )
 })


### PR DESCRIPTION
Closes https://linear.app/seam/issue/ACS-476/implement-seambridgev1bridge-client-sessions-endpoints-in-fake-seam

Pairing code was previously hardcoded to `123456` but Pairing codes should be randomized as it's used to identify a session.