### PR TITLE
fix(Bridge Client): set tailscale_auth_key to string

### DIFF
--- a/src/lib/database/seed.ts
+++ b/src/lib/database/seed.ts
@@ -243,7 +243,7 @@ export const seedDatabase = (db: Database): Seed => {
     pairing_code: "123456",
     pairing_code_expires_at: new Date().toISOString(),
     tailscale_hostname: "bcs1_tailscale_host",
-    tailscale_auth_key: ["bcs1_tailscale_key"],
+    tailscale_auth_key: "bcs1_tailscale_key",
     bridge_client_name: "bridge_1",
     bridge_client_time_zone: "America/Los_Angeles",
     bridge_client_machine_identifier_key: "bcs1_machine",

--- a/src/lib/database/store.ts
+++ b/src/lib/database/store.ts
@@ -309,7 +309,7 @@ const initializer = immer<Database>((set, get) => ({
       pairing_code: Math.floor(100000 + Math.random() * 900000).toString(),
       pairing_code_expires_at: new Date().toISOString(),
       tailscale_hostname: `${bridge_client_session_id}_tailscale_host`,
-      tailscale_auth_key: [`${bridge_client_session_id}_tailscale_auth`],
+      tailscale_auth_key: `${bridge_client_session_id}_tailscale_auth`,
       bridge_client_name: `${bridge_client_session_id}_bridge`,
       bridge_client_time_zone: "America/Los_Angeles",
       bridge_client_machine_identifier_key: `${bridge_client_session_id}_key`,

--- a/src/lib/zod/bridge_client_session.ts
+++ b/src/lib/zod/bridge_client_session.ts
@@ -7,7 +7,7 @@ export const bridge_client_session = z.object({
   pairing_code: z.string().length(6),
   pairing_code_expires_at: z.string().datetime(),
   tailscale_hostname: z.string(),
-  tailscale_auth_key: z.array(z.string()),
+  tailscale_auth_key: z.string().nullable(),
   bridge_client_name: z.string(),
   bridge_client_time_zone: z.string(),
   bridge_client_machine_identifier_key: z.string(),

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -4440,7 +4440,7 @@ export type Routes = {
         pairing_code: string
         pairing_code_expires_at: string
         tailscale_hostname: string
-        tailscale_auth_key: string[]
+        tailscale_auth_key: string | null
         bridge_client_name: string
         bridge_client_time_zone: string
         bridge_client_machine_identifier_key: string
@@ -4463,7 +4463,7 @@ export type Routes = {
         pairing_code: string
         pairing_code_expires_at: string
         tailscale_hostname: string
-        tailscale_auth_key: string[]
+        tailscale_auth_key: string | null
         bridge_client_name: string
         bridge_client_time_zone: string
         bridge_client_machine_identifier_key: string
@@ -4486,7 +4486,7 @@ export type Routes = {
         pairing_code: string
         pairing_code_expires_at: string
         tailscale_hostname: string
-        tailscale_auth_key: string[]
+        tailscale_auth_key: string | null
         bridge_client_name: string
         bridge_client_time_zone: string
         bridge_client_machine_identifier_key: string

--- a/test/fixtures/get-test-database.ts
+++ b/test/fixtures/get-test-database.ts
@@ -119,7 +119,7 @@ export const getTestDatabase = async (
     pairing_code: "123456",
     pairing_code_expires_at: new Date().toISOString(),
     tailscale_hostname: "bcs1_tailscale_host",
-    tailscale_auth_key: ["bcs1_tailscale_key"],
+    tailscale_auth_key: "bcs1_tailscale_key",
     bridge_client_name: "bridge_1",
     bridge_client_time_zone: "America/Los_Angeles",
     bridge_client_machine_identifier_key: "bcs1_machine",


### PR DESCRIPTION
Not sure why I had it set to an `array`, but it should be a `string`, same as actual connect.