### PR TITLE
fix: Fix module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,27 +27,14 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": "./",
     "paths": {
-      "@seamapi/fake-seam-connect": [
-        "./src/index.ts"
-      ],
-      "fixtures/*": [
-        "./test/fixtures/*"
-      ],
-      "lib/*": [
-        "./src/lib/*"
-      ],
-      "nsm/*": [
-        "./.nsm/*"
-      ],
-      "pages/*": [
-        "./src/pages/*"
-      ]
+      "@seamapi/fake-seam-connect": ["./src/index.ts"],
+      "fixtures/*": ["./test/fixtures/*"],
+      "lib/*": ["./src/lib/*"],
+      "nsm/*": ["./.nsm/*"],
+      "pages/*": ["./src/pages/*"]
     }
   },
-  "files": [
-    "src/index.ts",
-    "src/server.ts"
-  ],
+  "files": ["src/index.ts", "src/server.ts"],
   "include": [
     "src/**/*",
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
+    "module": "esnext",
     "moduleResolution": "nodenext",
     "allowJs": false,
     "target": "es2021",
@@ -26,14 +27,27 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": "./",
     "paths": {
-      "@seamapi/fake-seam-connect": ["./src/index.ts"],
-      "fixtures/*": ["./test/fixtures/*"],
-      "lib/*": ["./src/lib/*"],
-      "nsm/*": ["./.nsm/*"],
-      "pages/*": ["./src/pages/*"]
+      "@seamapi/fake-seam-connect": [
+        "./src/index.ts"
+      ],
+      "fixtures/*": [
+        "./test/fixtures/*"
+      ],
+      "lib/*": [
+        "./src/lib/*"
+      ],
+      "nsm/*": [
+        "./.nsm/*"
+      ],
+      "pages/*": [
+        "./src/pages/*"
+      ]
     }
   },
-  "files": ["src/index.ts", "src/server.ts"],
+  "files": [
+    "src/index.ts",
+    "src/server.ts"
+  ],
   "include": [
     "src/**/*",
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "allowJs": false,
     "target": "es2021",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "module": "NodeNext",
+    "module": "esnext",
     "moduleResolution": "nodenext",
     "allowJs": false,
     "target": "es2021",
@@ -27,14 +27,27 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": "./",
     "paths": {
-      "@seamapi/fake-seam-connect": ["./src/index.ts"],
-      "fixtures/*": ["./test/fixtures/*"],
-      "lib/*": ["./src/lib/*"],
-      "nsm/*": ["./.nsm/*"],
-      "pages/*": ["./src/pages/*"]
+      "@seamapi/fake-seam-connect": [
+        "./src/index.ts"
+      ],
+      "fixtures/*": [
+        "./test/fixtures/*"
+      ],
+      "lib/*": [
+        "./src/lib/*"
+      ],
+      "nsm/*": [
+        "./.nsm/*"
+      ],
+      "pages/*": [
+        "./src/pages/*"
+      ]
     }
   },
-  "files": ["src/index.ts", "src/server.ts"],
+  "files": [
+    "src/index.ts",
+    "src/server.ts"
+  ],
   "include": [
     "src/**/*",
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "module": "nodenext",
+    "module": "esnext",
     "moduleResolution": "nodenext",
     "allowJs": false,
     "target": "es2021",
@@ -27,14 +27,27 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": "./",
     "paths": {
-      "@seamapi/fake-seam-connect": ["./src/index.ts"],
-      "fixtures/*": ["./test/fixtures/*"],
-      "lib/*": ["./src/lib/*"],
-      "nsm/*": ["./.nsm/*"],
-      "pages/*": ["./src/pages/*"]
+      "@seamapi/fake-seam-connect": [
+        "./src/index.ts"
+      ],
+      "fixtures/*": [
+        "./test/fixtures/*"
+      ],
+      "lib/*": [
+        "./src/lib/*"
+      ],
+      "nsm/*": [
+        "./.nsm/*"
+      ],
+      "pages/*": [
+        "./src/pages/*"
+      ]
     }
   },
-  "files": ["src/index.ts", "src/server.ts"],
+  "files": [
+    "src/index.ts",
+    "src/server.ts"
+  ],
   "include": [
     "src/**/*",
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "NodeNext",
     "moduleResolution": "nodenext",
     "allowJs": false,
     "target": "es2021",


### PR DESCRIPTION
Fixed Zod import error causing type issues locally. TypeScript failed to resolve `z` export from Zod (`Module '"zod"' has no exported member 'z'`), which caused all schemas to be typed as `any` and broke type inference throughout the codebase. The issue seems to have stemmed from our tsconfig.json having `moduleResolution: "nodenext"` without the matching `module: "NodeNext"` setting. Adding the missing setting restored proper module resolution and type safety without changing any import statements.
