### PR TITLE
fix: Support query params and POST body for endpoints with GET/POST methods

### DIFF
--- a/src/pages/api/_fake/default_seed.ts
+++ b/src/pages/api/_fake/default_seed.ts
@@ -11,7 +11,7 @@ const seed_schema = z.object(
 
 export default withRouteSpec({
   auth: "none",
-  methods: ["GET"],
+  methods: ["GET", "POST"],
   jsonResponse: seed_schema,
 } as const)(async (_, res) => {
   res.status(200).json(seed)

--- a/src/pages/api/access_codes/delete.ts
+++ b/src/pages/api/access_codes/delete.ts
@@ -4,7 +4,7 @@ import { z } from "zod"
 import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
 import { action_attempt } from "lib/zod/action_attempt.ts"
 
-const json_body = z.object({
+const common_params = z.object({
   access_code_id: z.string(),
   device_id: z.string().optional(),
   sync: z.boolean().default(false),
@@ -18,12 +18,12 @@ export default withRouteSpec({
     "api_key",
   ],
   methods: ["POST", "DELETE"],
-  jsonBody: json_body,
+  commonParams: common_params,
   jsonResponse: z.object({
     action_attempt,
   }),
 } as const)(async (req, res) => {
-  const { access_code_id, device_id, sync } = req.body
+  const { access_code_id, device_id, sync } = req.commonParams
 
   const access_code = req.db.findAccessCode({ access_code_id, device_id })
 

--- a/src/pages/api/acs/users/remove_from_access_group.ts
+++ b/src/pages/api/acs/users/remove_from_access_group.ts
@@ -11,13 +11,13 @@ export default withRouteSpec({
     "console_session_with_workspace",
     "api_key",
   ],
-  jsonBody: z.object({
+  commonParams: z.object({
     acs_user_id: z.string(),
     acs_access_group_id: z.string(),
   }),
   jsonResponse: z.object({}),
 } as const)(async (req, res) => {
-  const { acs_user_id, acs_access_group_id } = req.body
+  const { acs_user_id, acs_access_group_id } = req.commonParams
 
   const acs_user = req.db.acs_users.find(
     (acs_user) =>

--- a/src/pages/api/connect_webviews/view.ts
+++ b/src/pages/api/connect_webviews/view.ts
@@ -4,8 +4,8 @@ import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
 
 export default withRouteSpec({
   auth: "none",
-  methods: ["GET"],
-  queryParams: z.object({}),
+  methods: ["GET", "POST"],
+  commonParams: z.object({}),
 } as const)(async (_req, res) => {
   res.status(200).end(`
     <html>

--- a/src/pages/api/connected_accounts/delete.ts
+++ b/src/pages/api/connected_accounts/delete.ts
@@ -11,13 +11,13 @@ export default withRouteSpec({
     "api_key",
   ],
   methods: ["DELETE", "POST"],
-  jsonBody: z.object({
+  commonParams: z.object({
     connected_account_id: z.string(),
     sync: z.boolean().default(false),
   }),
   jsonResponse: z.object({}),
 } as const)(async (req, res) => {
-  const { connected_account_id } = req.body
+  const { connected_account_id } = req.commonParams
 
   const connected_account = req.db.connected_accounts.find(
     (cw) => cw.connected_account_id === connected_account_id,

--- a/src/pages/api/internal/device_models/list.ts
+++ b/src/pages/api/internal/device_models/list.ts
@@ -13,8 +13,8 @@ const searchFields = [
 
 export default withRouteSpec({
   auth: "none",
-  methods: ["GET"],
-  queryParams: z.object({
+  methods: ["GET", "POST"],
+  commonParams: z.object({
     main_category: z.string().optional(),
     support_level: z.string().optional(),
     brand: z.string().optional(),
@@ -32,21 +32,21 @@ export default withRouteSpec({
   minisearch.addAll(fake_device_models)
 
   let device_models = [...fake_device_models]
-  if (req.query.text_search != null) {
-    device_models = minisearch.search(req.query.text_search) as any
+  if (req.commonParams.text_search != null) {
+    device_models = minisearch.search(req.commonParams.text_search) as any
   }
 
-  if (req.query.support_level != null) {
+  if (req.commonParams.support_level != null) {
     device_models = device_models.filter(
       (dm) =>
         dm.support_level.toLowerCase() ===
-        req.query.support_level?.toLowerCase(),
+        req.commonParams.support_level?.toLowerCase(),
     )
   }
 
-  if (req.query.brand != null) {
+  if (req.commonParams.brand != null) {
     device_models = device_models.filter(
-      (dm) => dm.brand.toLowerCase() === req.query.brand?.toLowerCase(),
+      (dm) => dm.brand.toLowerCase() === req.commonParams.brand?.toLowerCase(),
     )
   }
 

--- a/src/pages/api/internal/phone/deactivate.ts
+++ b/src/pages/api/internal/phone/deactivate.ts
@@ -5,12 +5,12 @@ import { withRouteSpec } from "lib/middleware/with-route-spec.ts"
 export default withRouteSpec({
   auth: "client_session",
   methods: ["DELETE", "POST"],
-  jsonBody: z.object({
+  commonParams: z.object({
     custom_sdk_installation_id: z.string(),
   }),
   jsonResponse: z.object({}),
 } as const)(async (req, res) => {
-  const { custom_sdk_installation_id } = req.body
+  const { custom_sdk_installation_id } = req.commonParams
 
   const { client_session_id, workspace_id } = req.auth
 

--- a/src/pages/api/noise_sensors/noise_thresholds/delete.ts
+++ b/src/pages/api/noise_sensors/noise_thresholds/delete.ts
@@ -17,7 +17,7 @@ export default withRouteSpec({
     "api_key",
   ],
   methods: ["DELETE", "POST"],
-  jsonBody: z.object({
+  commonParams: z.object({
     noise_threshold_id: z.string(),
     device_id: z.string(),
     sync: z.boolean().default(false),
@@ -26,7 +26,7 @@ export default withRouteSpec({
     action_attempt,
   }),
 } as const)(async (req, res) => {
-  const { device_id, sync, noise_threshold_id } = req.body
+  const { device_id, sync, noise_threshold_id } = req.commonParams
   const { workspace_id } = req.auth
 
   const device = getManagedDevicesWithFilter(req.db, {

--- a/src/pages/api/thermostats/heat_cool.ts
+++ b/src/pages/api/thermostats/heat_cool.ts
@@ -17,7 +17,7 @@ export default withRouteSpec({
     "api_key",
   ],
   methods: ["GET", "POST"],
-  jsonBody: z
+  commonParams: z
     .object({
       device_id: z.string(),
       heating_set_point_celsius: z.number().optional(),
@@ -73,7 +73,7 @@ export default withRouteSpec({
     cooling_set_point_celsius,
     cooling_set_point_fahrenheit,
     sync,
-  } = req.body
+  } = req.commonParams
 
   const device = req.db.devices.find((device) => {
     if (

--- a/src/route-types.ts
+++ b/src/route-types.ts
@@ -27,7 +27,7 @@ export type Routes = {
   }
   "/_fake/default_seed": {
     route: "/_fake/default_seed"
-    method: "GET"
+    method: "GET" | "POST"
     queryParams: {}
     jsonBody: {}
     commonParams: {}
@@ -382,12 +382,12 @@ export type Routes = {
     route: "/access_codes/delete"
     method: "POST" | "DELETE"
     queryParams: {}
-    jsonBody: {
+    jsonBody: {}
+    commonParams: {
       access_code_id: string
       device_id?: string | undefined
       sync?: boolean
     }
-    commonParams: {}
     formData: {}
     jsonResponse: {
       action_attempt:
@@ -1447,11 +1447,11 @@ export type Routes = {
     route: "/acs/users/remove_from_access_group"
     method: "DELETE" | "POST"
     queryParams: {}
-    jsonBody: {
+    jsonBody: {}
+    commonParams: {
       acs_user_id: string
       acs_access_group_id: string
     }
-    commonParams: {}
     formData: {}
     jsonResponse: {
       ok: boolean
@@ -1931,7 +1931,7 @@ export type Routes = {
   }
   "/connect_webviews/view": {
     route: "/connect_webviews/view"
-    method: "GET"
+    method: "GET" | "POST"
     queryParams: {}
     jsonBody: {}
     commonParams: {}
@@ -1943,11 +1943,11 @@ export type Routes = {
     route: "/connected_accounts/delete"
     method: "DELETE" | "POST"
     queryParams: {}
-    jsonBody: {
+    jsonBody: {}
+    commonParams: {
       connected_account_id: string
       sync?: boolean
     }
-    commonParams: {}
     formData: {}
     jsonResponse: {
       ok: boolean
@@ -2900,15 +2900,15 @@ export type Routes = {
   }
   "/internal/device_models/list": {
     route: "/internal/device_models/list"
-    method: "GET"
-    queryParams: {
+    method: "GET" | "POST"
+    queryParams: {}
+    jsonBody: {}
+    commonParams: {
       main_category?: string | undefined
       support_level?: string | undefined
       brand?: string | undefined
       text_search?: string | undefined
     }
-    jsonBody: {}
-    commonParams: {}
     formData: {}
     jsonResponse: {
       device_models: {
@@ -2948,10 +2948,10 @@ export type Routes = {
     route: "/internal/phone/deactivate"
     method: "DELETE" | "POST"
     queryParams: {}
-    jsonBody: {
+    jsonBody: {}
+    commonParams: {
       custom_sdk_installation_id: string
     }
-    commonParams: {}
     formData: {}
     jsonResponse: {
       ok: boolean
@@ -4367,12 +4367,12 @@ export type Routes = {
     route: "/noise_sensors/noise_thresholds/delete"
     method: "DELETE" | "POST"
     queryParams: {}
-    jsonBody: {
+    jsonBody: {}
+    commonParams: {
       noise_threshold_id: string
       device_id: string
       sync?: boolean
     }
-    commonParams: {}
     formData: {}
     jsonResponse: {
       action_attempt:
@@ -4706,7 +4706,8 @@ export type Routes = {
     route: "/thermostats/heat_cool"
     method: "GET" | "POST"
     queryParams: {}
-    jsonBody: {
+    jsonBody: {}
+    commonParams: {
       device_id: string
       heating_set_point_celsius?: number | undefined
       heating_set_point_fahrenheit?: number | undefined
@@ -4714,7 +4715,6 @@ export type Routes = {
       cooling_set_point_fahrenheit?: number | undefined
       sync?: boolean
     }
-    commonParams: {}
     formData: {}
     jsonResponse: {
       action_attempt:

--- a/test/api/_fake/default_seed.test.ts
+++ b/test/api/_fake/default_seed.test.ts
@@ -11,3 +11,12 @@ test("GET /_fake/default_seed", async (t: ExecutionContext) => {
 
   t.deepEqual(data_without_ok, seed)
 })
+
+test("POST /_fake/default_seed", async (t: ExecutionContext) => {
+  const { axios } = await getTestServer(t)
+
+  const { data } = await axios.post("/_fake/default_seed")
+  const { ok, ...data_without_ok } = data
+
+  t.deepEqual(data_without_ok, seed)
+})

--- a/test/api/access_codes/delete.test.ts
+++ b/test/api/access_codes/delete.test.ts
@@ -41,3 +41,33 @@ test("DELETE /access_codes/delete", async (t: ExecutionContext) => {
 
   t.falsy(deleted) // removed from db
 })
+
+test("POST /access_codes/delete", async (t: ExecutionContext) => {
+  const { axios, seed, db } = await getTestServer(t)
+  axios.defaults.headers.common.Authorization = `Bearer ${seed.ws2.cst}`
+
+  const {
+    data: { access_code },
+  } = await axios.post("/access_codes/create", {
+    device_id: seed.ws2.device1_id,
+    name: "Test Access Code",
+    code: "1234",
+  })
+
+  const {
+    data: { action_attempt },
+    status,
+  } = await axios.post("/access_codes/delete", {
+    access_code_id: access_code.access_code_id,
+    sync: true,
+  })
+
+  t.is(status, 200)
+  t.is(action_attempt.status, "success")
+
+  const deleted = db.findAccessCode({
+    access_code_id: access_code.access_code_id,
+  })
+
+  t.falsy(deleted)
+})

--- a/test/api/acs/users/remove_from_access_group.test.ts
+++ b/test/api/acs/users/remove_from_access_group.test.ts
@@ -30,3 +30,29 @@ test("POST /acs/users/add_to_access_group", async (t: ExecutionContext) => {
   )
   t.false(access_group?._acs_user_ids.includes(acs_user_id))
 })
+
+test("DELETE /acs/users/remove_from_access_group", async (t: ExecutionContext) => {
+  const { axios, seed, db } = await getTestServer(t)
+  axios.defaults.headers.common.Authorization = `Bearer ${seed.ws2.cst}`
+  const {
+    acs_user1_id: acs_user_id,
+    acs_access_group1_id: acs_access_group_id,
+  } = seed.ws2
+
+  await axios.post("/acs/users/add_to_access_group", {
+    acs_user_id,
+    acs_access_group_id,
+  })
+
+  await axios.delete("/acs/users/remove_from_access_group", {
+    params: {
+      acs_user_id,
+      acs_access_group_id,
+    },
+  })
+
+  const access_group = db.acs_access_groups.find(
+    (ag) => ag.acs_access_group_id === acs_access_group_id,
+  )
+  t.false(access_group?._acs_user_ids.includes(acs_user_id))
+})

--- a/test/api/connected_accounts/delete.test.ts
+++ b/test/api/connected_accounts/delete.test.ts
@@ -43,3 +43,25 @@ test("DELETE /connected_accounts/delete", async (t: ExecutionContext) => {
 
   t.is(devices_get_res.status, 404)
 })
+
+test("POST /connected_accounts/delete", async (t: ExecutionContext) => {
+  const { axios, seed } = await getTestServer(t)
+  const { connected_account1_id: connected_account_id } = seed.ws2
+  axios.defaults.headers.common.Authorization = `Bearer ${seed.ws2.cst}`
+
+  const { status } = await axios.post("/connected_accounts/delete", {
+    connected_account_id,
+  })
+
+  t.is(status, 200)
+
+  const connected_accounts_get_res = await axios.get(
+    "/connected_accounts/get",
+    {
+      params: { connected_account_id },
+      validateStatus: () => true,
+    },
+  )
+
+  t.is(connected_accounts_get_res.status, 404)
+})

--- a/test/api/internal/device_models/list.test.ts
+++ b/test/api/internal/device_models/list.test.ts
@@ -7,3 +7,14 @@ test("GET /internal/device_models/list", async (t: ExecutionContext) => {
   const { data } = await axios.get("/internal/device_models/list")
   t.true(data.device_models.length > 0)
 })
+
+test("POST /internal/device_models/list", async (t: ExecutionContext) => {
+  const { axios } = await getTestServer(t)
+  const { data } = await axios.post("/internal/device_models/list", {
+    brand: "yale",
+  })
+  t.true(data.device_models.length > 0)
+  t.true(
+    data.device_models.every((dm: { brand: string }) => dm.brand === "yale"),
+  )
+})

--- a/test/api/noise_sensors/noise_thresholds/delete.test.ts
+++ b/test/api/noise_sensors/noise_thresholds/delete.test.ts
@@ -33,3 +33,55 @@ test("DELETE /noise_sensors/noise_thresholds/delete", async (t: ExecutionContext
 
   t.is(noise_thresholds.length, 0)
 })
+
+test("DELETE /noise_sensors/noise_thresholds/delete with query params", async (t: ExecutionContext) => {
+  const { axios, seed } = await getTestServer(t)
+  axios.defaults.headers.common.Authorization = `Bearer ${seed.ws2.cst}`
+
+  const {
+    data: { action_attempt },
+  } = await axios.delete("/noise_sensors/noise_thresholds/delete", {
+    params: {
+      device_id: seed.ws2.noise_sensor_device_id,
+      noise_threshold_id: seed.ws2.noise_threshold_id,
+      sync: true,
+    },
+  })
+
+  t.is(action_attempt.status, "success")
+
+  const {
+    data: { noise_thresholds },
+  } = await axios.get("/noise_sensors/noise_thresholds/list", {
+    params: {
+      device_id: seed.ws2.noise_sensor_device_id,
+    },
+  })
+
+  t.is(noise_thresholds.length, 0)
+})
+
+test("POST /noise_sensors/noise_thresholds/delete", async (t: ExecutionContext) => {
+  const { axios, seed } = await getTestServer(t)
+  axios.defaults.headers.common.Authorization = `Bearer ${seed.ws2.cst}`
+
+  const {
+    data: { action_attempt },
+  } = await axios.post("/noise_sensors/noise_thresholds/delete", {
+    device_id: seed.ws2.noise_sensor_device_id,
+    noise_threshold_id: seed.ws2.noise_threshold_id,
+    sync: true,
+  })
+
+  t.is(action_attempt.status, "success")
+
+  const {
+    data: { noise_thresholds },
+  } = await axios.get("/noise_sensors/noise_thresholds/list", {
+    params: {
+      device_id: seed.ws2.noise_sensor_device_id,
+    },
+  })
+
+  t.is(noise_thresholds.length, 0)
+})

--- a/test/api/thermostats/heat_cool.test.ts
+++ b/test/api/thermostats/heat_cool.test.ts
@@ -61,6 +61,52 @@ test("POST /thermostats/heat_cool with api key", async (t) => {
   )
 })
 
+test("GET /thermostats/heat_cool with api key", async (t) => {
+  const { axios, db } = await getTestServer(t, { seed: false })
+  const seed_result = seedDatabase(db)
+
+  axios.defaults.headers.common.Authorization = `Bearer ${seed_result.seam_apikey1_token}`
+
+  const heating_set_point_celsius = 31
+  const cooling_set_point_celsius = 20
+
+  const {
+    data: { action_attempt },
+    status,
+  } = await axios.get("/thermostats/heat_cool", {
+    params: {
+      device_id: seed_result.ecobee_device_1,
+      heating_set_point_celsius,
+      cooling_set_point_celsius,
+      sync: true,
+    },
+  })
+
+  t.is(200, status)
+
+  t.is(action_attempt.status, "success")
+  t.is(action_attempt.action_type, "SET_HEAT_COOL")
+
+  const {
+    data: { device },
+  } = await axios.get("/devices/get", {
+    params: { device_id: seed_result.ecobee_device_1 },
+  })
+
+  const device_props = device.properties as z.infer<
+    typeof thermostat_device_properties
+  >
+  t.is(device_props.current_climate_setting.hvac_mode_setting, "heat_cool")
+  t.is(
+    device_props.current_climate_setting.heating_set_point_celsius,
+    heating_set_point_celsius,
+  )
+  t.is(
+    device_props.current_climate_setting.cooling_set_point_celsius,
+    cooling_set_point_celsius,
+  )
+})
+
 test("POST /thermostats/heat_cool (below min_heating_cooling_delta_celsius)", async (t) => {
   const { axios, db } = await getTestServer(t, { seed: false })
   const seed_result = seedDatabase(db)


### PR DESCRIPTION
## Summary
This PR refactors several API endpoints to support both GET and POST HTTP methods by moving parameters from `jsonBody` to `commonParams`. This allows these endpoints to accept parameters via query strings (for GET requests) or request body (for POST requests), improving API flexibility and consistency.

## Key Changes

- **Route type definitions**: Updated `src/route-types.ts` to move parameters from `jsonBody` to `commonParams` for endpoints that support both GET and POST methods:
  - `/access_codes/delete`
  - `/acs/users/remove_from_access_group`
  - `/connected_accounts/delete`
  - `/internal/device_models/list`
  - `/internal/phone/deactivate`
  - `/noise_sensors/noise_thresholds/delete`
  - `/thermostats/heat_cool`
  - `/_fake/default_seed`
  - `/connect_webviews/view`

- **Endpoint implementations**: Updated handler files to:
  - Change `methods` array to include both "GET" and "POST" where applicable
  - Move parameter validation from `jsonBody` to `commonParams` in route specs
  - Update request parameter access from `req.body` to `req.commonParams`

- **Test coverage**: Added comprehensive test cases for:
  - POST method variants of previously DELETE-only endpoints
  - GET method variant for `/thermostats/heat_cool`
  - POST method for `/internal/device_models/list`
  - POST method for `/_fake/default_seed`
  - Query parameter support for endpoints like `/noise_sensors/noise_thresholds/delete`

## Implementation Details

The `commonParams` field in route specs automatically handles parameter extraction from either query strings (GET) or request body (POST), eliminating the need for separate parameter handling logic. This maintains backward compatibility while enabling more flexible API usage patterns.

https://claude.ai/code/session_01LYqJAu36MX8U8Kw9MxCuuW